### PR TITLE
support single letter parameters

### DIFF
--- a/lib/awesome_spawn/command_line_builder.rb
+++ b/lib/awesome_spawn/command_line_builder.rb
@@ -10,6 +10,11 @@ module AwesomeSpawn
     #   prevent command line injection.  Keys as Symbols are prefixed with `--`,
     #   and `_` is replaced with `-`.
     #
+    #   - `{:k => "value"}`              generates `-k value`
+    #   - `[[:k, "value"]]`              generates `-k value`
+    #   - `{:k => "value"}`              generates `-k=value`
+    #   - `[[:k=, "value"]]`             generates `-k=value` <br /><br />
+    #
     #   - `{:key => "value"}`            generates `--key value`
     #   - `[[:key, "value"]]`            generates `--key value`
     #   - `{:key= => "value"}`           generates `--key=value`
@@ -92,7 +97,9 @@ module AwesomeSpawn
     end
 
     def convert_symbol_key(key)
-      "--#{key.to_s.tr("_", "-")}"
+      key = key.to_s
+      dash = key =~ /^.=?$/ ? "-" : "--"
+      "#{dash}#{key.tr("_", "-")}"
     end
 
     def sanitize_value(value)

--- a/spec/command_line_builder_spec.rb
+++ b/spec/command_line_builder_spec.rb
@@ -39,6 +39,14 @@ describe AwesomeSpawn::CommandLineBuilder do
         assert_params({"--user=" => "bob"}, "--user=bob")
       end
 
+      it "with single letter symbol" do
+        assert_params({:a => "val"}, "-a val")
+      end
+
+      it "with single letter symbol" do
+        assert_params({:a= => "val"}, "-a=val")
+      end
+
       it "with value requiring sanitization" do
         assert_params({"--pass" => "P@$s w0rd%"}, "--pass P@\\$s\\ w0rd\\%")
       end


### PR DESCRIPTION
Some commands only have short parameters. This makes them much better.

For the following input:

```
AwesomeSpawn.run("cm", f: "file1", k: "file2")
```

before pr:

```
cm --f file1 --k file2
```

after pr:

```
cm -f file1 -k file2
```

While `"-f" => "file1"` is a viable option, once you do that, you might as just use `["-f", "file1"]` or even `run("cm -f file1 -k file2")`.

Since I don't think there exist single letter long options (e.g.: `--f`), I don't think this change will adversely affect users, but it should be in the changelog.