### PR TITLE
fix rspec deprecation warnings

### DIFF
--- a/spec/awesome_spawn_spec.rb
+++ b/spec/awesome_spawn_spec.rb
@@ -9,7 +9,7 @@ describe AwesomeSpawn do
       it ":params won't be modified" do
         params      = {:user => "bob"}
         orig_params = params.dup
-        subject.stub(:launch => ["", "", 0])
+        allow(subject).to receive(:launch).and_return(["", "", 0])
         subject.send(run_method, "true", :params => params)
         expect(orig_params).to eq(params)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 
@@ -19,11 +18,12 @@ RSpec.configure do |config|
 end
 
 def disable_spawning
-  Open3.stub(:capture3).and_raise("Spawning is not permitted in specs.  Please change your spec to use expectations/stubs.")
+  allow(Open3).to receive(:capture3)
+    .and_raise("Spawning is not permitted in specs.  Please change your spec to use expectations/stubs.")
 end
 
 def enable_spawning
-  Open3.stub(:capture3).and_call_original
+  allow(Open3).to receive(:capture3).and_call_original
 end
 
 begin


### PR DESCRIPTION
Fix 2 rspec deprecation warnings.
- `X.stub(:y)` is now `allow(X).to receive(:y)`
- As of 3.0, config param `treat_symbols_as_metadata_keys_with_true_values` is no longer needed
