### PR TITLE
no need for separate in_data parameter

### DIFF
--- a/lib/awesome_spawn.rb
+++ b/lib/awesome_spawn.rb
@@ -67,12 +67,7 @@ module AwesomeSpawn
     output, error, status = "", "", nil
     command_line = build_command_line(command, params)
 
-    begin
-      output, error, status = launch(command_line, options)
-    ensure
-      output ||= ""
-      error  ||= ""
-    end
+    output, error, status = launch(command_line, options)
   rescue Errno::ENOENT => err
     raise NoSuchFileError.new(err.message) if NoSuchFileError.detected?(err.message)
     raise
@@ -94,7 +89,7 @@ module AwesomeSpawn
   def run!(command, options = {})
     command_result = run(command, options)
 
-    if command_result.exit_status != 0
+    if command_result.failure?
       message = "#{command} exit code: #{command_result.exit_status}"
       raise CommandResultError.new(message, command_result)
     end
@@ -111,7 +106,6 @@ module AwesomeSpawn
 
   def launch(command, spawn_options = {})
     output, error, status = Open3.capture3(command, spawn_options)
-    status &&= status.exitstatus
-    return output, error, status
+    return output || "", error || "", status && status.exitstatus
   end
 end


### PR DESCRIPTION
I've had this locally for a while.

Not sure if I like the change anymore since it adds 1 line :(

Also, it looks like if you are not using the output, `Kernel.system` may be more efficient in memory, per the example in the [ruby-doc](http://ruby-doc.org/stdlib-1.9.3/libdoc/open3/rdoc/Open3.html#method-c-capture3).
We'd probably use backticks, but doesn't look like it has the same security precautions since `;` can go through no problem.

It is also of note, that `Kernel.system("cmd", "arg1", "arg2")` properly escapes the parameters. Not sure if we can leverage what they are calling under the covers to do the escaping for us. (which is potentially more robust)
