### PR TITLE
Handle String for sanitize_value

### DIFF
--- a/lib/awesome_spawn/command_line_builder.rb
+++ b/lib/awesome_spawn/command_line_builder.rb
@@ -97,6 +97,8 @@ module AwesomeSpawn
 
     def sanitize_value(value)
       case value
+      when String
+        value.shellescape
       when Enumerable
         value.to_a.collect { |i| sanitize_value(i) }.compact
       when NilClass


### PR DESCRIPTION
Stumbled across this. While in ruby, a `String` is _not_ `Enumerable`, in our rails app, a `String` is `Enumerable`.

```
cd vmdb
ruby -e 'puts "".is_a?(Enumerable)' # => false
./bin/rails r 'puts "".is_a?(Enumerable)' # => true
```

This causes an infinte recursion:

```
sanitize("a")
  "a".to_a.collect { |i| sanitize_value(i) }.compact
    --> sanitize("a")
      ...
```

There isn't a way to recreate this here, since this uses standard ruby and not our rails patches.
This is the spec that caused the issue.

---

```
./bin/rspec ./spec/lib/miq_postgres_admin_spec.rb

require 'spec_helper'
require 'db_administration/miq_postgres_admin'

describe MiqPostgresAdmin do
  subject { described_class }

  it "should test database size" do
    #current = MiqDbConfig.current.options
    current = VMDB::Config.new("database").config[Rails.env.to_sym]
    @db_opts = {
      :hostname => current[:host],
      :dbname => current[:database],
      :username => current[:username],
      :password => current[:password]
    }
    expect(subject.database_size(@db_opts)).to be > 0
  end
end
```
