### PR TITLE
dont support `:in` parameter for run

### DIFF
--- a/lib/awesome_spawn.rb
+++ b/lib/awesome_spawn.rb
@@ -45,11 +45,10 @@ module AwesomeSpawn
   #
   # @param [String] command The command to run
   # @param [Hash] options The options for running the command.  Also accepts any
-  #   option that can be passed to Kernel.spawn, except `:out` and `:err`.
+  #   option that can be passed to Kernel.spawn, except `:in`, `:out` and `:err`.
   # @option options [Hash,Array] :params The command line parameters. See
   #   {#build_command_line} for how to specify params.
-  # @option options [String] :in_data Data to be passed on stdin.  If this option
-  #   is specified you cannot specify `:in`.
+  # @option options [String] :in_data Data to be passed on stdin.
   #
   # @raise [NoSuchFileError] if the `command` is not found
   # @return [CommandResult] the output stream, error stream, and exit status
@@ -57,7 +56,7 @@ module AwesomeSpawn
   def run(command, options = {})
     raise ArgumentError, "options cannot contain :out" if options.include?(:out)
     raise ArgumentError, "options cannot contain :err" if options.include?(:err)
-    raise ArgumentError, "options cannot contain :in if :in_data is specified" if options.include?(:in) && options.include?(:in_data)
+    raise ArgumentError, "options cannot contain :in" if options.include?(:in)
     options = options.dup
     params  = options.delete(:params)
     if (in_data = options.delete(:in_data))

--- a/spec/awesome_spawn_spec.rb
+++ b/spec/awesome_spawn_spec.rb
@@ -14,8 +14,10 @@ describe AwesomeSpawn do
         expect(orig_params).to eq(params)
       end
 
-      it ":in_data cannot be passed with :in" do
-        expect { subject.send(run_method, "true", :in_data => "XXXXX", :in => "/dev/null") } .to raise_error(ArgumentError)
+      it ":in is not supported" do
+        expect do
+          subject.send(run_method, "true", :in => "/dev/null")
+        end.to raise_error(ArgumentError, "options cannot contain :in")
       end
 
       it ":out is not supported" do


### PR DESCRIPTION
remove in parameter

When we changed to `Open3.capture3` we stopped supporting `:in`. It currently silently eats the parameter.

I added the following code to `awesome_spawn_spec`, but it did not work.
If you can think of any obvious issues with this code, then that would be great great.

```
require 'tempfile'
it ":in" do
  tmp = Tempfile.new('foo')
  begin
    tmp.write("line1\nline2")
    tmp.rewind
    # data is not getting read
    result = subject.send(run_method, "cat", :in => tmp)
    expect(result.exit_status).to eq(0)
    expect(result.output).to      eq("line1\nline2")
    # => error: expect("") to eq("line1\nline2")
  ensure
     tmp.close
     tmp.unlink
  end
end
```
