### PR TITLE
detect :err, :out, :in even if in array

### DIFF
--- a/lib/awesome_spawn.rb
+++ b/lib/awesome_spawn.rb
@@ -61,9 +61,8 @@ module AwesomeSpawn
   # @return [CommandResult] the output stream, error stream, and exit status
   # @see http://ruby-doc.org/core/Kernel.html#method-i-spawn Kernel.spawn
   def run(command, options = {})
-    raise ArgumentError, "options cannot contain :out" if options.include?(:out)
-    raise ArgumentError, "options cannot contain :err" if options.include?(:err)
-    raise ArgumentError, "options cannot contain :in" if options.include?(:in)
+    bad_keys = (options.keys.flatten & [:in, :out, :err]).map { |k| ":#{k}" }
+    raise ArgumentError, "options cannot contain #{bad_keys.join(", ")}" if bad_keys.any?
     options = options.dup
     params  = options.delete(:params)
     if (in_data = options.delete(:in_data))

--- a/spec/awesome_spawn_spec.rb
+++ b/spec/awesome_spawn_spec.rb
@@ -39,6 +39,12 @@ describe AwesomeSpawn do
           subject.send(run_method, "true", :err => "/dev/null")
         end.to raise_error(ArgumentError, "options cannot contain :err")
       end
+
+      it "array of outputs is not supported" do
+        expect do
+          subject.send(run_method, "true", [:err, :out, 3] => "/dev/null")
+        end.to raise_error(ArgumentError, "options cannot contain :err, :out")
+      end
     end
 
     context "with real execution" do


### PR DESCRIPTION
We often call into our libraries with `[:err, :out] => "/dev/null"`
this properly detects that.