### PR TITLE
add module for spec_helper

### DIFF
--- a/lib/awesome_spawn/spec_helper.rb
+++ b/lib/awesome_spawn/spec_helper.rb
@@ -1,0 +1,12 @@
+module AwesomeSpawn
+  module SpecHelper
+    def disable_spawning
+      allow(Open3).to receive(:capture3)
+        .and_raise("Spawning is not permitted in specs.  Please change your spec to use expectations/stubs.")
+    end
+
+    def enable_spawning
+      allow(Open3).to receive(:capture3).and_call_original
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@
 # loaded once.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'awesome_spawn/spec_helper'
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
@@ -14,16 +17,8 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = 'random'
 
+  include AwesomeSpawn::SpecHelper
   config.before { disable_spawning }
-end
-
-def disable_spawning
-  allow(Open3).to receive(:capture3)
-    .and_raise("Spawning is not permitted in specs.  Please change your spec to use expectations/stubs.")
-end
-
-def enable_spawning
-  allow(Open3).to receive(:capture3).and_call_original
 end
 
 begin


### PR DESCRIPTION
AwesomeSpawn calls out to processes. Tests tend not to want to actually spawn out.
We added that protection to our code, but all projects that use this also need to reimplement the same methods.

This packages up our methods to share with other projects.

Other projects will use:

```ruby
require 'awesome_spawn/spec_helper'

RSpec.configure do |config|
  include AwesomeSpawn::SpecHelper
  config.before { disable_spawning }
end
```

@Fryguy If you have another suggested style, just holler.
