### PR TITLE
Add 2.2, ruby-head/jruby-head, allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
+- "1.9.3"
+- "2.0"
+- "2.1"
+- "2.2"
+- ruby-head
+- jruby-head
+matrix:
+  allow_failures:
+  - rvm: ruby-head
+  - rvm: jruby-head
+  fast_finish: true


### PR DESCRIPTION
If required rubies fail tests, skip remaining tests via fast_finish.