### PR TITLE
support environment variables

### DIFF
--- a/spec/awesome_spawn_spec.rb
+++ b/spec/awesome_spawn_spec.rb
@@ -6,14 +6,19 @@ describe AwesomeSpawn do
 
   shared_examples_for "parses" do
     it "supports no options" do
-      allow(subject).to receive(:launch).with("true", {}).and_return(["", "", 0])
+      allow(subject).to receive(:launch).with({}, "true", {}).and_return(["", "", 0])
       subject.send(run_method, "true")
+    end
+
+    it "supports option :params and :env" do
+      allow(subject).to receive(:launch).with({"VAR" => "x"}, "true --user bob", {}).and_return(["", "", 0])
+      subject.send(run_method, "true", :params => {:user => "bob"}, :env => {"VAR" => "x"})
     end
 
     it "wont modify passed in options" do
       options      = {:params => {:user => "bob"}}
       orig_options = options.dup
-      allow(subject).to receive(:launch).with("true --user bob", {}).and_return(["", "", 0])
+      allow(subject).to receive(:launch).with({}, "true --user bob", {}).and_return(["", "", 0])
       subject.send(run_method, "true", options)
       expect(orig_options).to eq(options)
     end
@@ -21,7 +26,7 @@ describe AwesomeSpawn do
     it "wont modify passed in options[:params]" do
       params      = {:user => "bob"}
       orig_params = params.dup
-      allow(subject).to receive(:launch).with("true --user bob", {}).and_return(["", "", 0])
+      allow(subject).to receive(:launch).with({}, "true --user bob", {}).and_return(["", "", 0])
       subject.send(run_method, "true", :params => params)
       expect(orig_params).to eq(params)
     end
@@ -78,6 +83,12 @@ describe AwesomeSpawn do
         result = subject.send(run_method, "cat", :in_data => "line1\nline2")
         expect(result.exit_status).to eq(0)
         expect(result.output).to      eq("line1\nline2")
+      end
+
+      it "sets environment" do
+        result = subject.send(run_method, "echo ${ABC}", :env => {"ABC" => "yay!"})
+        expect(result.exit_status).to eq(0)
+        expect(result.output).to      eq("yay!\n")
       end
     end
 


### PR DESCRIPTION
When we detach a process, we tend to pass a set of environment variable.

This adds the `:env` option to `AwesomeSpawn#run` so users can specify both the env and argv for a spawned task.

