### PR TITLE
Show stderr when error occurs on command execution

### DIFF
--- a/lib/awesome_spawn/command_result_error.rb
+++ b/lib/awesome_spawn/command_result_error.rb
@@ -8,6 +8,7 @@ module AwesomeSpawn
     attr_reader :result
 
     def initialize(message, result)
+      message += " error was: #{result.error}" if !result.nil? && !result.error.empty?
       super(message)
       @result = result
     end


### PR DESCRIPTION
Awesome spawn is used to run external utilities. Sometimes rare error occurs, then we through exception like this:

```
AwesomeSpawn::CommandResultError: psql exit code: 2
```

Usually there is an stderr that is contains useful details that could help admins, operators, supporters, developers and qa. Let's publish this stderr to give quick clue.
