### PR TITLE
Add command pipe support through :pipe option

### DIFF
--- a/lib/awesome_spawn.rb
+++ b/lib/awesome_spawn.rb
@@ -6,6 +6,7 @@ require "awesome_spawn/no_such_file_error"
 require "awesome_spawn/null_logger"
 
 require "open3"
+require "core_ext/open3"
 
 module AwesomeSpawn
   extend self

--- a/lib/core_ext/open3.rb
+++ b/lib/core_ext/open3.rb
@@ -1,0 +1,52 @@
+module Open3
+  # This is a combination of the functionality of Open3.capture3 and
+  # Open3.pipeline_r
+  #
+  # Open3.pipeline_r doesn't support capturing stderr, so this method takes the
+  # setup code found in `Open3#popen3`, and the block from `Open3#capture3`,
+  # and combines them into a single method.
+  #
+  # Should have the same interface as `Open3.capture3`, but supports passing in
+  # pipes.
+  def pipe_capture3(env, cmds, stdin_data: '', binmode: false, **opts)
+    # Begin excerpt from Open3.popen3
+    in_r, in_w = IO.pipe
+    opts[:in] = in_r
+    in_w.sync = true
+
+    out_r, out_w = IO.pipe
+    opts[:out] = out_w
+
+    err_r, err_w = IO.pipe
+    opts[:err] = err_w
+    # End excerpt from Open3.popen3
+
+    # Inject global ENV to all commands
+    commands   = cmds.map { |cmd| Array(cmd).unshift(env) }
+    child_ios  = [in_r, out_w, err_w]
+    parent_ios = [in_w, out_r, err_r]
+
+    pipeline_run(commands, opts, child_ios, parent_ios) do |*result|
+      # Mostly the same as the block content in Open3#capture3, except that
+      # pipeline_run returns an array of Processes that have been piped to, and
+      # we just want the status of the last one.
+      pipe_in, pipe_out, pipe_err, child_pids = result
+      # Begin block excerpt from Open3#capture3
+      if binmode
+        pipe_in.binmode
+        pipe_out.binmode
+        pipe_err.binmode
+      end
+      out_reader = Thread.new { pipe_out.read }
+      err_reader = Thread.new { pipe_err.read }
+      begin
+        pipe_in.write(stdin_data)
+      rescue Errno::EPIPE # rubocop:disable Lint/HandleExceptions (original code)
+      end
+      pipe_in.close
+      # End block excerpt from Open3#capture3
+      [out_reader.value, err_reader.value, child_pids.last.value]
+    end
+  end
+  module_function :pipe_capture3
+end


### PR DESCRIPTION
Allows for specifying the `:pipe` option in `.run`/`.run!`, which can be used to pass nested pipes to the command that is parsed in the same fashion as the base command.  This also allows for piped commands to go through the same sanitation helpers in the `CommandLineBuilder` as the base command, though passing an unfiltered string is also supported.

This feature is intended to be used to support file splitting for dumps (maybe backups?) in ManageIQ/manageiq-appliance_console, allowing us to pass `:pipe` to `PostgresAdmin` for doing things like:

```console
$ pg_dump --format c --file my_pg.dump vmdb_production | split -a 5 -b 100m - /path/to/save/my_pg.dump.
# Creates the following files for a 400MB example dump:
#   /path/to/save/my_pg.dump.aaaaa
#   /path/to/save/my_pg.dump.aaaab
#   /path/to/save/my_pg.dump.aaaac
#   /path/to/save/my_pg.dump.aaaad
```

By doing something like:

```ruby
params = {
  :format => "c",
  :file   => "my_pg.dump",
  nil     => "vmdb_production"
}

pipe   = [
  "split",
  {
    :params => [[:a, '5'], [:b, "100m"], [nil, "-"], [nil, "/path/to/save/my_pg.dump"] }
  }
]

AwesomeSpawn.run!("pg_dump", :params => params, :pipe => pipe)
```


Testing/QA
----------

I have been testing this in practice by running the steps outlined in the following gist:

https://gist.github.com/NickLaMuro/8438015363d90a2d2456be650a2b9bc6