### PR TITLE
On error log STDOUT if STDERR is empty

### DIFF
--- a/lib/awesome_spawn.rb
+++ b/lib/awesome_spawn.rb
@@ -100,8 +100,10 @@ module AwesomeSpawn
 
     if command_result.failure?
       message = CommandResultError.default_message(command, command_result.exit_status)
+      error = command_result.error.nil? || command_result.error.empty? ? command_result.output : command_result.error
+
       logger.error("AwesomeSpawn: #{message}")
-      logger.error("AwesomeSpawn: #{command_result.error}")
+      logger.error("AwesomeSpawn: #{error}")
       raise CommandResultError.new(message, command_result)
     end
 


### PR DESCRIPTION
If a process doesn't correctly log to STDERR then the default .run! log
message isn't very helpful.  This logs command_result.error if it is
present, otherwise it logs command_result.output.