### PR TITLE
 Make AwesomeSpawn::SpecHelper work properly

### DIFF
--- a/lib/awesome_spawn/spec_helper.rb
+++ b/lib/awesome_spawn/spec_helper.rb
@@ -11,11 +11,11 @@ module AwesomeSpawn
       allow(Open3).to receive(:capture3).and_call_original
     end
 
-    def stub_good_run
+    def stub_good_run(command, options = {})
       stub_run(:good, :run, command, options)
     end
 
-    def stub_bad_run
+    def stub_bad_run(command, options = {})
       stub_run(:bad, :run, command, options)
     end
 
@@ -30,15 +30,14 @@ module AwesomeSpawn
     private
 
     def stub_run(mode, method, command, options)
-      output = options[:output] || ""
-      error  = options[:error]  || (mode == :bad ? "Failure" : "")
-      exit_status = options[:exit_status] || (mode == :bad ? 1 : 0)
+      options = options.dup
+      output = options.delete(:output) || ""
+      error  = options.delete(:error)  || (mode == :bad ? "Failure" : "")
+      exit_status = options.delete(:exit_status) || (mode == :bad ? 1 : 0)
 
-      params = options[:params]
-      command_line = AwesomeSpawn.build_command_line(command, params)
+      command_line = AwesomeSpawn.build_command_line(command, options[:params])
 
-      args = [command]
-      args << {:params => params} if params
+      args = [command, options]
 
       result = CommandResult.new(command_line, output, error, exit_status)
       if method == :run! && mode == :bad

--- a/spec/spec_helper_spec.rb
+++ b/spec/spec_helper_spec.rb
@@ -1,0 +1,13 @@
+describe AwesomeSpawn::SpecHelper do
+  describe ".stub_good_run" do
+    it "works" do
+      described_class.stub_good_run
+    end
+  end
+
+  describe ".stub_bad_run" do
+    it "works" do
+      described_class.stub_bad_run
+    end
+  end
+end

--- a/spec/spec_helper_spec.rb
+++ b/spec/spec_helper_spec.rb
@@ -1,13 +1,39 @@
+require 'spec_helper'
+
 describe AwesomeSpawn::SpecHelper do
-  describe ".stub_good_run" do
-    it "works" do
-      described_class.stub_good_run
+  include AwesomeSpawn::SpecHelper
+
+  let(:command) { "echo" }
+  let(:options) { {:params => {:n => nil, nil => "$STUFF"}, :env => {"STUFF" => "things"}} }
+
+  describe "#stub_good_run" do
+    it "returns a 0 exit status" do
+      stub_good_run(command, options)
+      result = AwesomeSpawn.run(command, options)
+      expect(result.exit_status).to eq(0)
     end
   end
 
-  describe ".stub_bad_run" do
-    it "works" do
-      described_class.stub_bad_run
+  describe "#stub_bad_run" do
+    it "returns a non-zero exit status" do
+      stub_bad_run(command, options)
+      result = AwesomeSpawn.run(command, options)
+      expect(result.exit_status).to_not eq(0)
+    end
+  end
+
+  describe "#stub_good_run!" do
+    it "returns a 0 exit status" do
+      stub_good_run!(command, options)
+      result = AwesomeSpawn.run!(command, options)
+      expect(result.exit_status).to eq(0)
+    end
+  end
+
+  describe "#stub_bad_run!" do
+    it "raises a CommandResultError" do
+      stub_bad_run!(command, options)
+      expect { AwesomeSpawn.run!(command, options) }.to raise_error(AwesomeSpawn::CommandResultError)
     end
   end
 end


### PR DESCRIPTION
This allows users to pass more than just the :params key
and also adds the missing parameters to #stub_good_run
and #stub_bad_run