### PR TITLE
Add :combined_output option

### DIFF
--- a/lib/awesome_spawn.rb
+++ b/lib/awesome_spawn.rb
@@ -62,6 +62,7 @@ module AwesomeSpawn
   # @option options [Hash,Array] :params The command line parameters. See
   #   {#build_command_line} for how to specify params.
   # @option options [String] :in_data Data to be passed on stdin.
+  # @option options [Boolean] :combined_output Combine STDOUT/STDERR streams from run command
   # @option options [Hash<String,String>] :env Additional environment variables for sub process
   #
   # @raise [NoSuchFileError] if the `command` is not found
@@ -118,7 +119,13 @@ module AwesomeSpawn
   private
 
   def launch(env, command, spawn_options)
-    output, error, status = Open3.capture3(env, command, spawn_options)
+    capture2e = spawn_options.delete(:combined_output)
+    if capture2e
+      output, status = Open3.capture2e(env, command, spawn_options)
+      error          = ""
+    else
+      output, error, status = Open3.capture3(env, command, spawn_options)
+    end
     return output, error, status && status.exitstatus
   end
 

--- a/spec/awesome_spawn_spec.rb
+++ b/spec/awesome_spawn_spec.rb
@@ -141,6 +141,20 @@ describe AwesomeSpawn do
       it "contains #error" do
         expect(subject.send(run_method, "echo 'bad' >&2 && false").error).to eq("bad\n")
       end
+
+      it "combines output when using :combined_output => true" do
+        result = subject.send(run_method, "echo good && echo 'bad' >&2 && false", :combined_output => true)
+
+        expect(result.output).to eq("good\nbad\n")
+        expect(result.error).to  eq("")
+      end
+
+      it "allows :combined_output to be falsey" do
+        result = subject.send(run_method, "echo good && echo 'bad' >&2 && false", :combined_output => false)
+
+        expect(result.output).to eq("good\n")
+        expect(result.error).to  eq("bad\n")
+      end
     end
   end
 

--- a/spec/awesome_spawn_spec.rb
+++ b/spec/awesome_spawn_spec.rb
@@ -31,25 +31,25 @@ describe AwesomeSpawn do
       expect(orig_params).to eq(params)
     end
 
-    it "warns about option :in" do
+    it "errors on option :in" do
       expect do
         subject.send(run_method, "true", :in => "/dev/null")
       end.to raise_error(ArgumentError, "options cannot contain :in")
     end
 
-    it "warns about option :out" do
+    it "errors on option :out" do
       expect do
         subject.send(run_method, "true", :out => "/dev/null")
       end.to raise_error(ArgumentError, "options cannot contain :out")
     end
 
-    it "warns about option :err" do
+    it "errors on option :err" do
       expect do
         subject.send(run_method, "true", :err => "/dev/null")
       end.to raise_error(ArgumentError, "options cannot contain :err")
     end
 
-    it "warns about option :err when in an array" do
+    it "errors on option :err when in an array" do
       expect do
         subject.send(run_method, "true", [:err, :out, 3] => "/dev/null")
       end.to raise_error(ArgumentError, "options cannot contain :err, :out")


### PR DESCRIPTION
Allows for combining `STDOUT` and `STDERR` streams into one stream, and makes the output available in both `.output` and `.error` (currently).