### PR TITLE
add pid to command result

### DIFF
--- a/lib/awesome_spawn/command_result.rb
+++ b/lib/awesome_spawn/command_result.rb
@@ -1,11 +1,12 @@
 module AwesomeSpawn
   class CommandResult
-    attr_reader :command_line, :output, :error, :exit_status
+    attr_reader :command_line, :output, :error, :pid, :exit_status
 
-    def initialize(command_line, output, error, exit_status)
+    def initialize(command_line, output, error, pid, exit_status)
       @command_line = command_line
       @output       = output
       @error        = error
+      @pid          = pid
       @exit_status  = exit_status
     end
 

--- a/lib/awesome_spawn/spec_helper.rb
+++ b/lib/awesome_spawn/spec_helper.rb
@@ -33,13 +33,14 @@ module AwesomeSpawn
       options = options.dup
       output = options.delete(:output) || ""
       error  = options.delete(:error)  || (mode == :bad ? "Failure" : "")
+      pid    = options.delete(:pid)    || ""
       exit_status = options.delete(:exit_status) || (mode == :bad ? 1 : 0)
 
       command_line = AwesomeSpawn.build_command_line(command, options[:params])
 
       args = [command, options]
 
-      result = CommandResult.new(command_line, output, error, exit_status)
+      result = CommandResult.new(command_line, output, error, pid, exit_status)
       if method == :run! && mode == :bad
         error_message = CommandResultError.default_message(command, exit_status)
         error = CommandResultError.new(error_message, result)

--- a/spec/awesome_spawn_spec.rb
+++ b/spec/awesome_spawn_spec.rb
@@ -3,30 +3,35 @@ require 'pathname' # For Pathname specific specs
 
 describe AwesomeSpawn do
   subject { described_class }
+  let(:status) { double("status") }
 
   shared_examples_for "parses" do
+    before do
+      allow(status).to receive_messages(:exitstatus => 0, :pid => 3)
+    end
+
     it "supports no options" do
-      allow(subject).to receive(:launch).with({}, "true", {}).and_return(["", "", 0])
+      allow(subject).to receive(:launch).with({}, "true", {}).and_return(["", "", status])
       subject.send(run_method, "true")
     end
 
     it "supports option :params and :env" do
-      allow(subject).to receive(:launch).with({"VAR" => "x"}, "true --user bob", {}).and_return(["", "", 0])
+      allow(subject).to receive(:launch).with({"VAR" => "x"}, "true --user bob", {}).and_return(["", "", status])
       subject.send(run_method, "true", :params => {:user => "bob"}, :env => {"VAR" => "x"})
     end
 
-    it "wont modify passed in options" do
+    it "won't modify passed in options" do
       options      = {:params => {:user => "bob"}}
       orig_options = options.dup
-      allow(subject).to receive(:launch).with({}, "true --user bob", {}).and_return(["", "", 0])
+      allow(subject).to receive(:launch).with({}, "true --user bob", {}).and_return(["", "", status])
       subject.send(run_method, "true", options)
       expect(orig_options).to eq(options)
     end
 
-    it "wont modify passed in options[:params]" do
+    it "won't modify passed in options[:params]" do
       params      = {:user => "bob"}
       orig_params = params.dup
-      allow(subject).to receive(:launch).with({}, "true --user bob", {}).and_return(["", "", 0])
+      allow(subject).to receive(:launch).with({}, "true --user bob", {}).and_return(["", "", status])
       subject.send(run_method, "true", :params => params)
       expect(orig_params).to eq(params)
     end

--- a/spec/command_result_spec.rb
+++ b/spec/command_result_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe AwesomeSpawn::CommandResult do
   context "succeeding object" do
-    subject { described_class.new("aaa", "bbb", "ccc", 0) }
+    subject { described_class.new("aaa", "bbb", "ccc", 10_000, 0) }
 
     it "should set attributes" do
       expect(subject.command_line).to eq("aaa")
       expect(subject.output).to eq("bbb")
       expect(subject.error).to eq("ccc")
       expect(subject.exit_status).to eq(0)
+      expect(subject.pid).to eq(10_000)
       expect(subject.inspect).to match(/^#<AwesomeSpawn::CommandResult:[0-9a-fx]+ @exit_status=0>$/)
     end
 
@@ -23,14 +24,14 @@ describe AwesomeSpawn::CommandResult do
   end
 
   context "failing object" do
-    subject { described_class.new("aaa", "bbb", "ccc", 1) }
+    subject { described_class.new("aaa", "bbb", "ccc", 10_001, 1) }
 
     it { expect(subject).not_to be_a_success }
     it { expect(subject).to be_a_failure }
   end
 
   context "another failing object" do
-    subject { described_class.new("aaa", "bbb", "ccc", 100) }
+    subject { described_class.new("aaa", "bbb", "ccc", 10_002, 100) }
 
     it { expect(subject).not_to be_a_success }
     it { expect(subject).to be_a_failure }


### PR DESCRIPTION
i'm fixing a brakeman warning in system_console about `pid = spawn(*command)`
and i'd like to have command result be able to return the pid