### PR TITLE
Removing deprecated Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://travis-ci.org/ManageIQ/awesome_spawn.png)](https://travis-ci.org/ManageIQ/awesome_spawn)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/awesome_spawn.png)](https://codeclimate.com/github/ManageIQ/awesome_spawn)
 [![Coverage Status](https://coveralls.io/repos/ManageIQ/awesome_spawn/badge.png?branch=master)](https://coveralls.io/r/ManageIQ/awesome_spawn)
-[![Dependency Status](https://gemnasium.com/ManageIQ/awesome_spawn.png)](https://gemnasium.com/ManageIQ/awesome_spawn)
 
 AwesomeSpawn is a module that provides some useful features over Ruby's Kernel.spawn.
 


### PR DESCRIPTION
Functionality has been replaced by GitHub's dependency graph and security alerts.