### PR TITLE
remove sudo from travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 rvm:
 - "2.0"


### PR DESCRIPTION
we can remove `sudo:false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration: `If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon.`

@miq-bot add_label cleanup
@miq-bot assign @kbrock