### PR TITLE
update ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: ruby
 rvm:
-- "2.0"
-- "2.1"
-- "2.2"
-- "2.3.3"
-- "2.4.0"
+- "2.5.8"
+- "2.6.6"
 - ruby-head
 - jruby-head
 matrix:


### PR DESCRIPTION
2.4 was EOL almost a year ago, do we need to keep supporting these?