### PR TITLE
handle numeric environment variables

### DIFF
--- a/lib/awesome_spawn.rb
+++ b/lib/awesome_spawn.rb
@@ -164,7 +164,7 @@ module AwesomeSpawn
   def parse_command_options(command, options)
     options = options.dup
     params  = options.delete(:params)
-    env = options.delete(:env) || {}
+    env = (options.delete(:env) || {}).map { |n, v| [n.to_s, v&.to_s] }.to_h
 
     [env, build_command_line(command, params), options]
   end

--- a/spec/awesome_spawn_spec.rb
+++ b/spec/awesome_spawn_spec.rb
@@ -90,10 +90,46 @@ describe AwesomeSpawn do
         expect(result.output).to      eq("line1\nline2")
       end
 
-      it "sets environment" do
-        result = subject.send(run_method, "echo ${ABC}", :env => {"ABC" => "yay!"})
+      it "handles numeric parameters" do
+        result = subject.send(run_method, "echo ${ABC}", :params => [5], :env => {"ABC" => "yay!"})
         expect(result.exit_status).to eq(0)
-        expect(result.output).to      eq("yay!\n")
+        expect(result.output).to      eq("yay! 5\n")
+      end
+
+      it "handles numeric env variables" do
+        result = subject.send(run_method, "echo v=${ABC}", :env => {"ABC" => 5})
+        expect(result.exit_status).to eq(0)
+        expect(result.output).to      eq("v=5\n")
+      end
+
+      it "handles blank env variables (not checking presence)" do
+        result = subject.send(run_method, "echo v=\"'${ABC-none}'\"", :env => {"ABC" => ""})
+        expect(result.exit_status).to eq(0)
+        expect(result.output).to      eq("v=''\n")
+      end
+
+      it "handles blank env variables (checking presence)" do
+        result = subject.send(run_method, "echo v=\"'${ABC:-none}'\"", :env => {"ABC" => ""})
+        expect(result.exit_status).to eq(0)
+        expect(result.output).to      eq("v='none'\n")
+      end
+
+      it "handles nil env variables (not checking presence)" do
+        result = subject.send(run_method, "echo v=\"'${ABC-none}'\"", :env => {"ABC" => nil})
+        expect(result.exit_status).to eq(0)
+        expect(result.output).to      eq("v='none'\n")
+      end
+
+      it "handles nil env variables (checking presence)" do
+        result = subject.send(run_method, "echo v=\"'${ABC:-none}'\"", :env => {"ABC" => nil})
+        expect(result.exit_status).to eq(0)
+        expect(result.output).to      eq("v='none'\n")
+      end
+
+      it "handles symbolic env keys and values" do
+        result = subject.send(run_method, "echo ${ABC}", :env => {:ABC => :yay})
+        expect(result.exit_status).to eq(0)
+        expect(result.output).to      eq("yay\n")
       end
     end
 


### PR DESCRIPTION
`Kernel.spawn` does not support integer environment variables.

So we now convert them to strings