### PR TITLE
Add SpecHelper.disable_spawning helper method

### DIFF
--- a/lib/awesome_spawn/spec_helper.rb
+++ b/lib/awesome_spawn/spec_helper.rb
@@ -2,6 +2,34 @@ require 'awesome_spawn'
 
 module AwesomeSpawn
   module SpecHelper
+    # Disable spawning for specs
+    #
+    # @example Disable spawning for all specs
+    #   RSpec.configure do |config|
+    #     AwesomeSpawn::SpecHelper.disable_spawning(config)
+    #   end
+    #
+    # @example Disable spawning for specs in a specific path
+    #   RSpec.configure do |config|
+    #     AwesomeSpawn::SpecHelper.disable_spawning(config, file_path: "spec/models")
+    #   end
+    #
+    # @param config [RSpec::Core::Configuration] RSpec configuration
+    # @param file_path [String] Restrict the disabling to a specific set of specs in the given path
+    def self.disable_spawning(config, file_path: nil)
+      if file_path
+        config.define_derived_metadata(:file_path => file_path) do |metadata|
+          metadata[:uses_awesome_spawn] = true
+        end
+        config.include AwesomeSpawn::SpecHelper, :uses_awesome_spawn => true
+        config.before(:each, :uses_awesome_spawn) { disable_spawning }
+      else
+        config.include AwesomeSpawn::SpecHelper
+        config.before { disable_spawning }
+      end
+      config
+    end
+
     def disable_spawning
       allow(Open3).to receive(:capture3)
         .and_raise("Spawning is not permitted in specs.  Please change your spec to use expectations/stubs.")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,7 @@ end
 require 'awesome_spawn/spec_helper'
 
 RSpec.configure do |config|
-  include AwesomeSpawn::SpecHelper
-  config.before { disable_spawning }
+  AwesomeSpawn::SpecHelper.disable_spawning(config)
 end
 
 require 'awesome_spawn'


### PR DESCRIPTION
This helps simplify the setup for RSpec, particularly when you only want to disable_spawning in particular specs.

@agrare Please review.