### PR TITLE
Fix sporadic test failure matching inspect

### DIFF
--- a/spec/command_result_spec.rb
+++ b/spec/command_result_spec.rb
@@ -14,9 +14,9 @@ describe AwesomeSpawn::CommandResult do
     end
 
     it "should not display sensitive information" do
-      expect(subject.inspect).to_not include("aaa")
-      expect(subject.inspect).to_not include("bbb")
-      expect(subject.inspect).to_not include("ccc")
+      expect(subject.inspect).to_not match(/^#<AwesomeSpawn::CommandResult:[0-9a-fx]+ .*aaa.*/)
+      expect(subject.inspect).to_not match(/^#<AwesomeSpawn::CommandResult:[0-9a-fx]+ .*bbb.*/)
+      expect(subject.inspect).to_not match(/^#<AwesomeSpawn::CommandResult:[0-9a-fx]+ .*ccc.*/)
     end
 
     it { expect(subject).to be_a_success }


### PR DESCRIPTION
```ruby
AwesomeSpawn::CommandResult.new("ls", "file list", "no error", 55, 0).inspect
=> "#<AwesomeSpawn::CommandResult:0x000000016099b9c8 @exit_status=0>"
```

Before
======

If the `CommandResult#object_id` has aaa (bbb, ccc) in it, the test fails

After
=====

The test does not match the pattern to the object_id
