### PR TITLE
[WIP] Use `Kernel.spawn(command, argv, ...)` instead of one big string

### DIFF
--- a/lib/awesome_spawn.rb
+++ b/lib/awesome_spawn.rb
@@ -71,13 +71,14 @@ module AwesomeSpawn
   def run(command, options = {})
     bad_keys = (options.keys.flatten & [:in, :out, :err]).map { |k| ":#{k}" }
     raise ArgumentError, "options cannot contain #{bad_keys.join(", ")}" if bad_keys.any?
-    env, command_line, options = parse_command_options(command, options)
+    env, cmd, args, options = parse_command_options(command, options)
 
     if (in_data = options.delete(:in_data))
       options[:stdin_data] = in_data
     end
 
-    output, error, process_status = launch(env, command_line, options)
+    command_line = args.empty? ? cmd : "#{cmd} #{args.join(' ')}"
+    output, error, process_status = launch(env, cmd, args, options)
     status = process_status && process_status.exitstatus
     pid = process_status.pid if process_status
 
@@ -129,7 +130,7 @@ module AwesomeSpawn
   #
   # if a user defines :out or :err, it is assumed they will define both
   def run_detached(command, options = {})
-    env, command_line, options = parse_command_options(command, options)
+    env, cmd, args, options = parse_command_options(command, options)
     # maybe add support later for this
     raise ArgumentError, "options cannot contain :in_data" if options.include?(:in_data)
 
@@ -140,24 +141,36 @@ module AwesomeSpawn
       options[:pgroup]      = true unless options.key?(:pgroup)
     end
 
-    detach(env, command_line, options)
+    detach(env, cmd, args, options)
   end
 
   # (see CommandLineBuilder#build)
   def build_command_line(command, params = nil)
-    CommandLineBuilder.new.build(command, params)
+    cmd, args = CommandLineBuilder.new.build(command, params)
+    args.empty? ? cmd : "#{cmd} #{args.join(' ')}"
   end
 
   private
 
-  def launch(env, command, spawn_options)
+  def launch(env, command, args, spawn_options)
     capture2e = spawn_options.delete(:combined_output)
-    if capture2e
-      output, status = Open3.capture2e(env, command, spawn_options)
+
+    # If command contains shell metacharacters, use shell interpretation
+    if command.match?(/[${}`|&;<>()]/)
+      full_command = args.empty? ? command : "#{command} #{args.join(' ')}"
+      if capture2e
+        output, status = Open3.capture2e(env, full_command, spawn_options)
+        error          = ""
+      else
+        output, error, status = Open3.capture3(env, full_command, spawn_options)
+      end
+    elsif capture2e
+      output, status = Open3.capture2e(env, command, *args, spawn_options)
       error          = ""
     else
-      output, error, status = Open3.capture3(env, command, spawn_options)
+      output, error, status = Open3.capture3(env, command, *args, spawn_options)
     end
+
     return output, error, status
   end
 
@@ -165,11 +178,12 @@ module AwesomeSpawn
     options = options.dup
     params  = options.delete(:params)
     env = (options.delete(:env) || {}).map { |n, v| [n.to_s, v&.to_s] }.to_h
+    cmd, args = CommandLineBuilder.new.build(command, params)
 
-    [env, build_command_line(command, params), options]
+    [env, cmd, args, options]
   end
 
-  def detach(env, command, options)
-    Process.detach(Kernel.spawn(env, command, options)).pid
+  def detach(env, command, args, options)
+    Process.detach(Kernel.spawn(env, command, *args, options)).pid
   end
 end

--- a/lib/awesome_spawn/command_line_builder.rb
+++ b/lib/awesome_spawn/command_line_builder.rb
@@ -42,19 +42,24 @@ module AwesomeSpawn
     #   - `[[nil, "file1", "file2"]]`    generates `file1 file2`
     #   - `[["file1", "file2"]]`         generates `file1 file2`
     #
-    # @return [String] The full command line
+    # @return [Array] An array containing the command and an array of arguments
     def build(command, params = nil)
-      params = assemble_params(sanitize(params))
-      params.empty? ? command.to_s : "#{command} #{params}"
+      args = assemble_params_array(sanitize(params))
+      [command.to_s, args]
     end
 
     private
 
-    def assemble_params(sanitized_params)
-      sanitized_params.collect do |group|
-        joiner = group.first.to_s.end_with?("=") ? "" : " "
-        group.compact.join(joiner)
-      end.join(" ")
+    def assemble_params_array(sanitized_params)
+      sanitized_params.flat_map do |group|
+        if group.first.to_s.end_with?("=")
+          # For key=value format, join them as one argument
+          [group.compact.join]
+        else
+          # For key value format, flatten any nested arrays
+          group.compact.flatten
+        end
+      end
     end
 
     def sanitize(params)
@@ -68,7 +73,13 @@ module AwesomeSpawn
 
     def sanitize_item(item)
       case item
-      when Array then sanitize_key_values(item[0], item[1..-1])
+      when Array
+        # If array contains a single Hash, process the Hash directly
+        if item.length == 1 && item[0].kind_of?(Hash)
+          sanitize_associative_array(item[0])
+        else
+          sanitize_key_values(item[0], item[1..-1])
+        end
       when Hash  then sanitize_associative_array(item)
       else            sanitize_key_values(item, nil)
       end
@@ -106,7 +117,7 @@ module AwesomeSpawn
       when NilClass
         value
       else
-        value.to_s.shellescape
+        value.to_s
       end
     end
   end

--- a/spec/awesome_spawn_spec.rb
+++ b/spec/awesome_spawn_spec.rb
@@ -11,19 +11,19 @@ describe AwesomeSpawn do
     end
 
     it "supports no options" do
-      allow(subject).to receive(:launch).with({}, "true", {}).and_return(["", "", status])
+      allow(subject).to receive(:launch).with({}, "true", [], {}).and_return(["", "", status])
       subject.send(run_method, "true")
     end
 
     it "supports option :params and :env" do
-      allow(subject).to receive(:launch).with({"VAR" => "x"}, "true --user bob", {}).and_return(["", "", status])
+      allow(subject).to receive(:launch).with({"VAR" => "x"}, "true", ["--user", "bob"], {}).and_return(["", "", status])
       subject.send(run_method, "true", :params => {:user => "bob"}, :env => {"VAR" => "x"})
     end
 
     it "won't modify passed in options" do
       options      = {:params => {:user => "bob"}}
       orig_options = options.dup
-      allow(subject).to receive(:launch).with({}, "true --user bob", {}).and_return(["", "", status])
+      allow(subject).to receive(:launch).with({}, "true", ["--user", "bob"], {}).and_return(["", "", status])
       subject.send(run_method, "true", options)
       expect(orig_options).to eq(options)
     end
@@ -31,7 +31,7 @@ describe AwesomeSpawn do
     it "won't modify passed in options[:params]" do
       params      = {:user => "bob"}
       orig_params = params.dup
-      allow(subject).to receive(:launch).with({}, "true --user bob", {}).and_return(["", "", status])
+      allow(subject).to receive(:launch).with({}, "true", ["--user", "bob"], {}).and_return(["", "", status])
       subject.send(run_method, "true", :params => params)
       expect(orig_params).to eq(params)
     end

--- a/spec/command_line_builder_spec.rb
+++ b/spec/command_line_builder_spec.rb
@@ -4,253 +4,266 @@ describe AwesomeSpawn::CommandLineBuilder do
   subject { described_class.new }
 
   context "#build" do
-    def assert_params(params, expected_params)
-      expect(subject.build("true", params)).to eq "true #{expected_params}".strip
+    def assert_params(params, expected_args)
+      cmd, args = subject.build("true", params)
+      expect(cmd).to eq "true"
+      expect(args).to eq expected_args
     end
 
     it "without params" do
-      expect(subject.build("true")).to eq "true"
+      cmd, args = subject.build("true")
+      expect(cmd).to eq "true"
+      expect(args).to eq []
     end
 
     it "with nil" do
-      expect(subject.build("true", nil)).to eq "true"
+      cmd, args = subject.build("true", nil)
+      expect(cmd).to eq "true"
+      expect(args).to eq []
     end
 
     it "with empty" do
-      expect(subject.build("true", "")).to eq "true"
+      cmd, args = subject.build("true", "")
+      expect(cmd).to eq "true"
+      expect(args).to eq []
     end
 
     it "with empty" do
-      expect(subject.build("true", [])).to eq "true"
+      cmd, args = subject.build("true", [])
+      expect(cmd).to eq "true"
+      expect(args).to eq []
     end
 
     it "with Pathname command" do
-      actual = subject.build(Pathname.new("/usr/bin/ruby"))
-      expect(actual).to eq "/usr/bin/ruby"
+      cmd, args = subject.build(Pathname.new("/usr/bin/ruby"))
+      expect(cmd).to eq "/usr/bin/ruby"
+      expect(args).to eq []
     end
 
     it "with Pathname command and params" do
-      actual = subject.build(Pathname.new("/usr/bin/ruby"), "-v" => nil)
-      expect(actual).to eq "/usr/bin/ruby -v"
+      cmd, args = subject.build(Pathname.new("/usr/bin/ruby"), "-v" => nil)
+      expect(cmd).to eq "/usr/bin/ruby"
+      expect(args).to eq ["-v"]
     end
 
     it "with Pathname in params" do
       options = ["-d", Pathname.new("script.rb")]
 
-      actual = subject.build(Pathname.new("/usr/bin/ruby"), options)
-      expect(actual).to eq "/usr/bin/ruby -d script.rb"
+      cmd, args = subject.build(Pathname.new("/usr/bin/ruby"), options)
+      expect(cmd).to eq "/usr/bin/ruby"
+      expect(args).to eq ["-d", "script.rb"]
     end
 
     context "with Hash" do
       it "that is empty" do
-        assert_params({}, "")
+        assert_params({}, [])
       end
 
       it "with normal params" do
-        assert_params({"--user" => "bob"}, "--user bob")
+        assert_params({"--user" => "bob"}, ["--user", "bob"])
       end
 
       it "with key with tailing '='" do
-        assert_params({"--user=" => "bob"}, "--user=bob")
+        assert_params({"--user=" => "bob"}, ["--user=bob"])
       end
 
       it "with single letter symbol" do
-        assert_params({:a => "val"}, "-a val")
+        assert_params({:a => "val"}, ["-a", "val"])
       end
 
       it "with single letter symbol" do
-        assert_params({:a= => "val"}, "-a=val")
+        assert_params({:a= => "val"}, ["-a=val"])
       end
 
       it "with value requiring sanitization" do
-        assert_params({"--pass" => "P@$s w0rd%"}, "--pass P@\\$s\\ w0rd\\%")
+        assert_params({"--pass" => "P@$s w0rd%"}, ["--pass", "P@$s w0rd%"])
       end
 
       it "with key requiring sanitization" do
-        assert_params({"--h&x0r=" => "xxx"}, "--h\\&x0r=xxx")
+        assert_params({"--h&x0r=" => "xxx"}, ["--h&x0r=xxx"])
       end
 
       it "with key as Symbol" do
-        assert_params({:abc => "def"}, "--abc def")
+        assert_params({:abc => "def"}, ["--abc", "def"])
       end
 
       it "with key as Symbol with tailing '='" do
-        assert_params({:abc= => "def"}, "--abc=def")
+        assert_params({:abc= => "def"}, ["--abc=def"])
       end
 
       it "with key as Symbol with underscore" do
-        assert_params({:abc_def => "ghi"}, "--abc-def ghi")
+        assert_params({:abc_def => "ghi"}, ["--abc-def", "ghi"])
       end
 
       it "with key as Symbol with underscore and tailing '='" do
-        assert_params({:abc_def= => "ghi"}, "--abc-def=ghi")
+        assert_params({:abc_def= => "ghi"}, ["--abc-def=ghi"])
       end
 
       it "with key as nil" do
-        assert_params({nil => "def"}, "def")
+        assert_params({nil => "def"}, ["def"])
       end
 
       it "with value as nil" do
-        assert_params({"--abc" => nil}, "--abc")
+        assert_params({"--abc" => nil}, ["--abc"])
       end
 
       it "with key and value nil" do
-        assert_params({nil => nil}, "")
+        assert_params({nil => nil}, [])
       end
 
       it "with key of '--'" do
-        assert_params({"--" => nil}, "--")
+        assert_params({"--" => nil}, ["--"])
       end
 
       it "with value as Symbol" do
-        assert_params({"--abc" => :def}, "--abc def")
+        assert_params({"--abc" => :def}, ["--abc", "def"])
       end
 
       it "with value as Array" do
-        assert_params({"--abc" => ["def", "ghi"]}, "--abc def ghi")
+        assert_params({"--abc" => ["def", "ghi"]}, ["--abc", "def", "ghi"])
       end
 
       it "with value as Fixnum" do
-        assert_params({"--abc" => 1}, "--abc 1")
+        assert_params({"--abc" => 1}, ["--abc", "1"])
       end
 
       it "with value as Fixnum Array" do
-        assert_params({"--abc" => [1, 2]}, "--abc 1 2")
+        assert_params({"--abc" => [1, 2]}, ["--abc", "1", "2"])
       end
 
       it "with value as Range" do
-        assert_params({"--abc" => (1..4)}, "--abc 1 2 3 4")
+        assert_params({"--abc" => (1..4)}, ["--abc", "1", "2", "3", "4"])
       end
 
       it "with value as Pathname" do
-        assert_params({"--abc" => Pathname.new("/usr/bin/ruby")}, "--abc /usr/bin/ruby")
+        assert_params({"--abc" => Pathname.new("/usr/bin/ruby")}, ["--abc", "/usr/bin/ruby"])
       end
     end
 
     context "with associative Array" do
       it "that is empty" do
-        assert_params([], "")
+        assert_params([], [])
       end
 
       it "that is nested empty" do
-        assert_params([[]], "")
+        assert_params([[]], [])
       end
 
       it "with normal params" do
-        assert_params([["--user", "bob"]], "--user bob")
+        assert_params([["--user", "bob"]], ["--user", "bob"])
       end
 
       it "with key with tailing '='" do
-        assert_params([["--user=", "bob"]], "--user=bob")
+        assert_params([["--user=", "bob"]], ["--user=bob"])
       end
 
       it "with value requiring sanitization" do
-        assert_params([["--pass", "P@$s w0rd%"]], "--pass P@\\$s\\ w0rd\\%")
+        assert_params([["--pass", "P@$s w0rd%"]], ["--pass", "P@$s w0rd%"])
       end
 
       it "with key requiring sanitization" do
-        assert_params([["--h&x0r=", "xxx"]], "--h\\&x0r=xxx")
+        assert_params([["--h&x0r=", "xxx"]], ["--h&x0r=xxx"])
       end
 
       it "with key as Symbol" do
-        assert_params([[:abc, "def"]], "--abc def")
+        assert_params([[:abc, "def"]], ["--abc", "def"])
       end
 
       it "with key as Symbol with tailing '='" do
-        assert_params([[:abc=, "def"]], "--abc=def")
+        assert_params([[:abc=, "def"]], ["--abc=def"])
       end
 
       it "with key as Symbol with underscore" do
-        assert_params([[:abc_def, "ghi"]], "--abc-def ghi")
+        assert_params([[:abc_def, "ghi"]], ["--abc-def", "ghi"])
       end
 
       it "with key as Symbol with underscore and tailing '='" do
-        assert_params([[:abc_def=, "ghi"]], "--abc-def=ghi")
+        assert_params([[:abc_def=, "ghi"]], ["--abc-def=ghi"])
       end
 
       it "with key as nil" do
-        assert_params([[nil, "def"]], "def")
+        assert_params([[nil, "def"]], ["def"])
       end
 
       it "with value as nil" do
-        assert_params([["--abc", nil]], "--abc")
+        assert_params([["--abc", nil]], ["--abc"])
       end
 
       it "with key and value nil" do
-        assert_params([[nil, nil]], "")
+        assert_params([[nil, nil]], [])
       end
 
       it "with key as nil and multiple values" do
-        assert_params([[nil, "def", "ghi"]], "def ghi")
+        assert_params([[nil, "def", "ghi"]], ["def", "ghi"])
       end
 
       it "with key of '--'" do
-        assert_params([["--", nil]], "--")
+        assert_params([["--", nil]], ["--"])
       end
 
       it "with key alone" do
-        assert_params([["--abc"]], "--abc")
+        assert_params([["--abc"]], ["--abc"])
       end
 
       it "with key as Symbol alone" do
-        assert_params([[:abc]], "--abc")
+        assert_params([[:abc]], ["--abc"])
       end
 
       it "with key as a bareword" do
-        assert_params(["--abc"], "--abc")
+        assert_params(["--abc"], ["--abc"])
       end
 
       it "with key as bareword Symbol" do
-        assert_params([:abc], "--abc")
+        assert_params([:abc], ["--abc"])
       end
 
       it "with value as a bareword" do
-        assert_params(["abc"], "abc")
+        assert_params(["abc"], ["abc"])
       end
 
       it "with entry as a nested Hash" do
-        assert_params([{:abc_def= => "ghi"}], "--abc-def=ghi")
+        assert_params([{:abc_def= => "ghi"}], ["--abc-def=ghi"])
       end
 
       it "with value as Symbol" do
-        assert_params([["--abc" => :def]], "--abc def")
+        assert_params([[{"--abc" => :def}]], ["--abc", "def"])
       end
 
       it "with value as Array" do
-        assert_params([["--abc", ["def", "ghi"]]], "--abc def ghi")
+        assert_params([["--abc", ["def", "ghi"]]], ["--abc", "def", "ghi"])
       end
 
       it "with value as Array and extra nils" do
-        assert_params([["--abc", [nil, "def", nil, "ghi", nil]]], "--abc def ghi")
+        assert_params([["--abc", [nil, "def", nil, "ghi", nil]]], ["--abc", "def", "ghi"])
       end
 
       it "with value as flattened Array" do
-        assert_params([["--abc", "def", "ghi"]], "--abc def ghi")
+        assert_params([["--abc", "def", "ghi"]], ["--abc", "def", "ghi"])
       end
 
       it "with value as Fixnum" do
-        assert_params([["--abc", 1]], "--abc 1")
+        assert_params([["--abc", 1]], ["--abc", "1"])
       end
 
       it "with value as Fixnum Array" do
-        assert_params([["--abc", [1, 2]]], "--abc 1 2")
+        assert_params([["--abc", [1, 2]]], ["--abc", "1", "2"])
       end
 
       it "with value as Range" do
-        assert_params([["--abc", (1..4)]], "--abc 1 2 3 4")
+        assert_params([["--abc", (1..4)]], ["--abc", "1", "2", "3", "4"])
       end
 
       it "with value as Pathname" do
-        assert_params([["--abc", Pathname.new("/usr/bin/ruby")]], "--abc /usr/bin/ruby")
+        assert_params([["--abc", Pathname.new("/usr/bin/ruby")]], ["--abc", "/usr/bin/ruby"])
       end
 
       it "with duplicate keys" do
-        assert_params([["--abc", 1], ["--abc", 2]], "--abc 1 --abc 2")
+        assert_params([["--abc", 1], ["--abc", 2]], ["--abc", "1", "--abc", "2"])
       end
     end
 
     context "with multiple params" do # real-world cases
-      let(:expected) { "log feature -E --oneline --grep abc" }
+      let(:expected) { ["log", "feature", "-E", "--oneline", "--grep", "abc"] }
 
       it "as full Hash" do
         params = {"log" => nil, "feature" => nil, "-E" => nil, :oneline => nil, "--grep" => "abc"}


### PR DESCRIPTION
When `Kernel.spawn` receives a `command` with spaces it uses `/bin/sh -c'command'` to execute the command.  This complicates terminating the returned `pid` because the actuall command is being run by a subprocess, and terminating `sh -c` doesn't terminate the detached child.

Example:

Start a detached process:
```
vmdb(dev)> pid = AwesomeSpawn.run_detached('podman', :params => ["events", [:format, "{{json .}}"]])
=> 2009825
```

Here we see `sh -c` with the command as a child process
```
$ ps aux | grep podman | grep -v grep
adam     2009825  0.0  0.0   2676  1488 pts/2    S    13:34   0:00 sh -c podman events --format \{\{json\ .\}\}
adam     2009827  0.8  0.0 3327036 38340 pts/2   Sl   13:34   0:00 podman events --format {{json .}}
```

If I kill -TERM the pid returned by awesome_spawn
```
vmdb(dev)> Process.kill("TERM", 2009825)
=> 1
```

It only terminates the `sh -c` process, not the actual `podman events` process.
```
$ ps aux | grep podman | grep -v grep
adam     2009827  0.2  0.0 3327036 38360 pts/2   Sl   13:34   0:00 podman events --format {{json .}}
```